### PR TITLE
refactor ServerError Exception

### DIFF
--- a/aerospike_plugin.py
+++ b/aerospike_plugin.py
@@ -21,7 +21,6 @@ __copyright__ = "Copyright 2020 Aerospike"
 __version__ = "3.0.0"
 
 import aerospike
-from aerospike.exception import ServerError
 import collectd
 import os
 import re
@@ -444,7 +443,7 @@ def datacenters(client, config, meta, emit):
         # If this fails, then it is either not EE edition or it is a pre 5.0 version.
         collectd.debug('Failed to execute info "%s" - %s' % (req, e))
         meta['timeouts'] += 1
-    except ServerError as e:
+    except aerospike.exception.ServerError as e:
         # If this fails, cluster may not have xdr enabled at all.
         collectd.info('Failed to execute info "%s" - %s' % (req, e))
         meta['timeouts'] += 1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 pyyaml
-collectd
+git+https://github.com/appliedsec/collectd.git@feature/python3-support
 aerospike==3.10.0


### PR DESCRIPTION
no need to explictly import exceptions submodule

Fixing this new issue:
ModuleNotFoundError: No module named 'aerospike.exception'; 'aerospike' is not a package